### PR TITLE
[박송이] feat: DetailDeniedLog 컴포넌트화 완료 #21

### DIFF
--- a/src/components/atoms/DeniedTag.tsx
+++ b/src/components/atoms/DeniedTag.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import styled, { css } from 'styled-components';
+import BaseLayoutProps from '../types/BaseLayoutProps';
+
+export interface TagProps extends BaseLayoutProps {}
+
+const DeniedTagStyled = styled.div`
+  ${({ theme }) => css`
+    width: max-content;
+    padding: 2px 4px;
+    border-radius: 5px;
+    background-color: ${theme.colors.pink};
+    color: ${theme.colors.red};
+    font-size: ${theme.fonts.size.xxs};
+    font-weight: ${theme.fonts.weight.bold};
+    line-height: ${theme.fonts.lineHeight.xs};
+  `}
+`;
+
+export default function DeniedTag(props: TagProps) {
+  return <DeniedTagStyled {...props} />;
+}

--- a/src/components/molecules/DetailDeniedLog.tsx
+++ b/src/components/molecules/DetailDeniedLog.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import styled, { css } from 'styled-components';
+import BaseLayoutProps from '../types/BaseLayoutProps';
+import DeniedTag from '../atoms/DeniedTag';
+
+export interface DeniedProps extends BaseLayoutProps {
+  date: Date;
+  tag: tag[];
+  reason: string;
+}
+
+export interface tag {
+  tagId: number;
+  tagName: string;
+}
+
+function formatDate(t: Date) {
+  return `${t.getFullYear().toString()}.${(
+    '0' + (t.getMonth() + 1).toString()
+  ).slice(-2)}.${('0' + t.getDate().toString()).slice(-2)} ${(
+    '0' + t.getHours().toString()
+  ).slice(-2)}:${('0' + t.getMinutes().toString()).slice(-2)}:${(
+    '0' + t.getSeconds().toString()
+  ).slice(-2)}`;
+}
+
+const DeniedLogStyled = styled.section`
+  width: 360px;
+  padding: 20px 25px;
+  border: 1px solid #eeeeee;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const DeniedDate = styled.p`
+  ${({ theme }) => css`
+    margin-bottom: 15px;
+    color: ${theme.colors.black};
+    font-weight: ${theme.fonts.weight.bold};
+    font-size: ${theme.fonts.size.m};
+    line-height: ${theme.fonts.lineHeight.m};
+  `}
+`;
+
+const DeniedTagWrapper = styled.div`
+  margin: 10px 0;
+`;
+
+const DeniedReasonWrapper = styled.section`
+  margin-top: 15px;
+`;
+
+const DeniedEtc = styled.div`
+  ${({ theme }) => css`
+    margin-bottom: 5px;
+    color: ${theme.colors.gray2};
+    font-size: ${theme.fonts.size.xxs};
+    line-height: ${theme.fonts.lineHeight.xs};
+  `}
+`;
+
+const DeniedReason = styled.p`
+  ${({ theme }) => css`
+    width: 310px;
+    color: ${theme.colors.gray3};
+    font-size: ${theme.fonts.size.ms};
+    line-height: ${theme.fonts.lineHeight.msL};
+  `}
+`;
+
+export default function DetailDeniedLog({
+  date,
+  tag,
+  reason,
+  ...props
+}: DeniedProps): JSX.Element {
+  return (
+    <DeniedLogStyled>
+      <DeniedDate>{formatDate(date)}</DeniedDate>
+      {tag.map(tagData => (
+        <DeniedTagWrapper key={tagData.tagId}>
+          <DeniedTag>{tagData.tagName}</DeniedTag>
+        </DeniedTagWrapper>
+      ))}
+      <DeniedReasonWrapper>
+        <DeniedEtc>기타</DeniedEtc>
+        <DeniedReason {...props}>
+          {reason === '' ? `없음` : props.children}
+        </DeniedReason>
+      </DeniedReasonWrapper>
+    </DeniedLogStyled>
+  );
+}

--- a/src/components/molecules/DetailDeniedLog.tsx
+++ b/src/components/molecules/DetailDeniedLog.tsx
@@ -14,6 +14,7 @@ export interface tag {
   tagName: string;
 }
 
+//Date formatting 함수
 function formatDate(t: Date) {
   return `${t.getFullYear().toString()}.${(
     '0' + (t.getMonth() + 1).toString()


### PR DESCRIPTION
## 개요
분자 단위의 DetailDeniedLog 컴포넌트화

## 작업 사항
props로 반려 날짜, 반려 이유 태그, 반려 이유 내용, 태그 아이디, 태그 이유 받도록 했습니다.

## 기타
코드 리뷰때 받은 삼항 연산자 썼던 부분(Denied Reason styled-component)의 코드 중복을 수정하였습니다.