### PR TITLE
[박송이] feat: MainLayout 작업 및 Mainpage 초기 작업 #30

### DIFF
--- a/public/data/MainItemList.json
+++ b/public/data/MainItemList.json
@@ -1,0 +1,154 @@
+[
+  {
+    "contentId": "1",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "2",
+    "stateLabel": "approved",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "3",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "4",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "5",
+    "stateLabel": "denied",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "6",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "7",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "8",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "9",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "10",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "11",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "12",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "13",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "14",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "15",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "16",
+    "stateLabel": "denied",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  },
+  {
+    "contentId": "17",
+    "stateLabel": "processing",
+    "thumb": "",
+    "subject": "string",
+    "uploadedAt": "2022-02-02 11:11:11",
+    "latestDeniedAt": "2022-02-02 11:11:11",
+    "tags": ["강아지", "동물", "귀여움", "자연"]
+  }
+]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
   Route,
   Routes,
 } from 'react-router-dom';
-import ConfirmContentsPage from './pages/ConfirmContents';
+import ConfirmContentsPage from './pages/ConfirmContents/Main';
 import ConfirmContentDetailPage from './pages/ConfirmContents/ConfirmContentDetail';
 import theme from './styles/theme';
 import GlobalStyle from './styles/globlaStyles';

--- a/src/components/templates/MainLayout.tsx
+++ b/src/components/templates/MainLayout.tsx
@@ -26,17 +26,7 @@ const PagenationWrapper = styled.section`
 `;
 
 export default function MainLayout({ type }: MainItemLayoutProps) {
-  const [mainItemList, setMainItemList] = useState<MainDataProps[]>([
-    {
-      contentId: '',
-      stateLabel: undefined,
-      thumb: '',
-      subject: '',
-      uploadedAt: '',
-      latestDeniedAt: '',
-      tags: [],
-    },
-  ]);
+  const [mainItemList, setMainItemList] = useState<MainDataProps[]>([]);
 
   //mainItemList 데이터 fetch
   useEffect(() => {
@@ -60,22 +50,23 @@ export default function MainLayout({ type }: MainItemLayoutProps) {
   return (
     <>
       <MainItemStyled>
-        {mainItemList.map(data => (
-          <MainItem
-            key={data.contentId}
-            stateType={data.stateLabel}
-            imgSrc={data.thumb}
-            imgAlt={data.subject}
-            title={data.subject}
-            uploadDate={new Date(data.uploadedAt)}
-            tagArray={data.tags}
-            lastDeniedDate={
-              data.latestDeniedAt === undefined
-                ? undefined
-                : new Date(data.latestDeniedAt)
-            }
-          />
-        ))}
+        {mainItemList.length > 0 &&
+          mainItemList.map(data => (
+            <MainItem
+              key={data.contentId}
+              stateType={data.stateLabel}
+              imgSrc={data.thumb}
+              imgAlt={data.subject}
+              title={data.subject}
+              uploadDate={new Date(data.uploadedAt)}
+              tagArray={data.tags}
+              lastDeniedDate={
+                data.latestDeniedAt === undefined
+                  ? undefined
+                  : new Date(data.latestDeniedAt)
+              }
+            />
+          ))}
       </MainItemStyled>
       <PagenationWrapper>
         <Pagenation />

--- a/src/components/templates/MainLayout.tsx
+++ b/src/components/templates/MainLayout.tsx
@@ -1,22 +1,20 @@
-import styled from 'styled-components';
-import BaseLayoutProps from '../types/BaseLayoutProps';
-import * as React from 'react';
-import MainItem from '../molecules/MainItem';
-import { MainDataProps } from '../types/CommonDataProps';
-import Pagenation from '../../components/atoms/Pagenation';
-import { ConfirmContentsType } from '../../hooks/pathParams/useConfirmContentsParams';
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-
+import styled from 'styled-components';
+import MainItem from '../molecules/MainItem';
+import Pagenation from '../../components/atoms/Pagenation';
+import BaseLayoutProps from '../types/BaseLayoutProps';
+import { MainDataProps } from '../types/CommonDataProps';
+import { ConfirmContentsType } from '../../hooks/pathParams/useConfirmContentsParams';
 export interface MainItemLayoutProps extends BaseLayoutProps {
   type: ConfirmContentsType;
 }
 
 const MainItemStyled = styled.div`
-  width: 1200px;
   display: flex;
-  gap: 60px 8px;
   flex-wrap: wrap;
+  gap: 60px 8px;
+  width: 1200px;
   margin: auto;
   padding: 45px 0 86px 0;
 `;
@@ -40,10 +38,23 @@ export default function MainLayout({ type }: MainItemLayoutProps) {
     },
   ]);
 
+  //mainItemList 데이터 fetch
   useEffect(() => {
     axios
       .get('http://localhost:3000/data/MainItemList.json')
-      .then(res => setMainItemList(res.data));
+      .then(res => setMainItemList(res.data))
+      .catch(err => {
+        if (err.response) {
+          console.log(err.response.data);
+          console.log(err.response.status);
+          console.log(err.response.headers);
+        } else if (err.request) {
+          console.log(err.request);
+        } else {
+          console.log('Error', err.message);
+        }
+        console.log(err.config);
+      });
   }, []);
 
   return (

--- a/src/components/templates/MainLayout.tsx
+++ b/src/components/templates/MainLayout.tsx
@@ -1,0 +1,74 @@
+import styled from 'styled-components';
+import BaseLayoutProps from '../types/BaseLayoutProps';
+import * as React from 'react';
+import MainItem from '../molecules/MainItem';
+import { MainDataProps } from '../types/CommonDataProps';
+import Pagenation from '../../components/atoms/Pagenation';
+import { ConfirmContentsType } from '../../hooks/pathParams/useConfirmContentsParams';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+export interface MainItemLayoutProps extends BaseLayoutProps {
+  type: ConfirmContentsType;
+}
+
+const MainItemStyled = styled.div`
+  width: 1200px;
+  display: flex;
+  gap: 60px 8px;
+  flex-wrap: wrap;
+  margin: auto;
+  padding: 45px 0 86px 0;
+`;
+
+const PagenationWrapper = styled.section`
+  display: flex;
+  justify-content: center;
+  padding-bottom: 120px;
+`;
+
+export default function MainLayout({ type }: MainItemLayoutProps) {
+  const [mainItemList, setMainItemList] = useState<MainDataProps[]>([
+    {
+      contentId: '',
+      stateLabel: undefined,
+      thumb: '',
+      subject: '',
+      uploadedAt: '',
+      latestDeniedAt: '',
+      tags: [],
+    },
+  ]);
+
+  useEffect(() => {
+    axios
+      .get('http://localhost:3000/data/MainItemList.json')
+      .then(res => setMainItemList(res.data));
+  }, []);
+
+  return (
+    <>
+      <MainItemStyled>
+        {mainItemList.map(data => (
+          <MainItem
+            key={data.contentId}
+            stateType={data.stateLabel}
+            imgSrc={data.thumb}
+            imgAlt={data.subject}
+            title={data.subject}
+            uploadDate={new Date(data.uploadedAt)}
+            tagArray={data.tags}
+            lastDeniedDate={
+              data.latestDeniedAt === undefined
+                ? undefined
+                : new Date(data.latestDeniedAt)
+            }
+          />
+        ))}
+      </MainItemStyled>
+      <PagenationWrapper>
+        <Pagenation />
+      </PagenationWrapper>
+    </>
+  );
+}

--- a/src/components/types/CommonDataProps.ts
+++ b/src/components/types/CommonDataProps.ts
@@ -18,3 +18,13 @@ interface DenyLogsType {
   deniedAt: string;
   denyTags: string[];
 }
+
+export interface MainDataProps extends BaseLayoutProps {
+  contentId: string;
+  stateLabel?: Exclude<TagProps['tagType'], 'tag'>;
+  thumb: string;
+  subject: string;
+  uploadedAt: string;
+  latestDeniedAt?: string;
+  tags: string[];
+}

--- a/src/pages/ConfirmContents/Main.tsx
+++ b/src/pages/ConfirmContents/Main.tsx
@@ -4,6 +4,12 @@ import useConfirmContentsParams, {
 } from '../../hooks/pathParams/useConfirmContentsParams';
 import HStackLayout from '../../components/atoms/layouts/HStackLayout';
 import MainTab from '../../components/molecules/MainTab';
+import styled from 'styled-components';
+import MainLayout from '../../components/templates/MainLayout';
+
+const MainTabWrapper = styled.section`
+  margin: 31px 0 0 100px;
+`;
 
 export default function ConfirmContentsPage() {
   const { type, setType } = useConfirmContentsParams();
@@ -25,8 +31,10 @@ export default function ConfirmContentsPage() {
 
   return (
     <VStackLayout>
-      <HStackLayout>{mainTabType.map(renderTypeButton)}</HStackLayout>
-      <h1>{type}</h1>
+      <HStackLayout>
+        <MainTabWrapper>{mainTabType.map(renderTypeButton)}</MainTabWrapper>
+      </HStackLayout>
+      <MainLayout type={type} />
     </VStackLayout>
   );
 }


### PR DESCRIPTION
## 개요
MainLayout 완료

##  작업사항
main의 레이아웃을 잡기 위해 layout 단에서 목데이터를 fetch해 와서 map을 돌렸습니다. 

## 기타
mainTab의 경우 메인 페이지에서 처리해주고자 대략 만들어두었고, 대기중 | 반려됨 | 승인에 대한 탭 타입을 props로 넘겨주어 나중에 리스트 목록을 불러오는 get API ('/content?state=:contentState&contentId=:contentId&start=:start&lim=:limit') 부분에서 contentState에 type을 넣어 불러오도록 할 생각입니다. 해당 방식에 문제가 있을까요?