### PR TITLE
[김수빈] 반려사유 글자 수 제한 QA 수정 - #22

### DIFF
--- a/src/components/atoms/TextBtn.tsx
+++ b/src/components/atoms/TextBtn.tsx
@@ -30,12 +30,13 @@ const Btn = styled.button<ButtonProps>`
     };
     text-align: center;
     cursor: pointer;
+    transition: ease-in-out 0.15s;
 
     &:hover {
       ${
         btnTheme === 'white'
           ? `color: ${theme.colors.gray2}`
-          : `box-shadow: ${theme.hoverShadow[btnTheme]}; transition: ease-in-out 0.15s;`
+          : `box-shadow: ${theme.hoverShadow[btnTheme]}`
       }
     }
   
@@ -43,7 +44,7 @@ const Btn = styled.button<ButtonProps>`
       ${
         btnTheme === 'white'
           ? `color: ${theme.colors.black}`
-          : `box-shadow: ${theme.pressedShadow[btnTheme]}; transition: ease-in-out 0.15s;`
+          : `box-shadow: ${theme.pressedShadow[btnTheme]}`
       }
   `}
 `;

--- a/src/components/atoms/texts/Tag.tsx
+++ b/src/components/atoms/texts/Tag.tsx
@@ -27,6 +27,7 @@ function handleMessage({ tagType, children }: TagProps) {
 function styling({ tagType }: TagProps) {
   let style: ReturnType<typeof css>;
   let commonFont: ReturnType<typeof css> = css`
+    padding: 2px 4px;
     border-radius: 5px;
     font-size: ${({ theme }) => theme.fonts.size.xxs};
     font-weight: ${({ theme }) => theme.fonts.weight.bold};
@@ -35,6 +36,7 @@ function styling({ tagType }: TagProps) {
   switch (tagType) {
     case 'tag':
       style = css`
+        padding: 4px 6px;
         border-radius: 10px;
         background-color: ${({ theme }) => theme.colors.sky};
         color: ${({ theme }) => theme.colors.blue};
@@ -71,7 +73,6 @@ const TagStyled = styled.div`
   ${styling}
   min-width: fit-content;
   width: max-content;
-  padding: 2px 4px;
 
   line-height: ${({ theme }) => theme.fonts.lineHeight.xs};
 `;

--- a/src/components/molecules/DetailDeniedReason.tsx
+++ b/src/components/molecules/DetailDeniedReason.tsx
@@ -149,6 +149,8 @@ export default function DetailDeniedReason({
     if (maxLength > 500) {
       modalStore.openModal('LimitText');
       setReasonText(() => reasonText.substring(0, maxLength));
+    } else {
+      setReasonText(value);
     }
   };
 
@@ -174,7 +176,6 @@ export default function DetailDeniedReason({
           placeholder="추가적인 반려사유가 있다면 작성해주세요."
           value={reasonText}
           onChange={e => {
-            setReasonText(e.target.value);
             limitText(e.target.value);
           }}
         />

--- a/src/components/molecules/DetailDeniedReason.tsx
+++ b/src/components/molecules/DetailDeniedReason.tsx
@@ -30,10 +30,14 @@ const DetailDeniendReasonWrapper = styled.div`
       font-weight: ${theme.fonts.weight.bold};
     }
 
-    h2 {
+    h2,
+    h3 {
       color: ${theme.colors.gray2};
       font-size: ${theme.fonts.size.xxs};
       line-height: ${theme.fonts.lineHeight.xs};
+    }
+    h3 {
+      text-align: right;
     }
   `}
 `;
@@ -140,6 +144,14 @@ export default function DetailDeniedReason({
     return submitArr;
   });
 
+  const limitText = (value: string) => {
+    const maxLength = value.length;
+    if (maxLength > 500) {
+      modalStore.openModal('LimitText');
+      setReasonText(() => reasonText.substring(0, maxLength));
+    }
+  };
+
   return (
     <DetailDeniendReasonStyled {...rest}>
       <DetailDeniendReasonWrapper>
@@ -160,8 +172,13 @@ export default function DetailDeniedReason({
         <h2>기타</h2>
         <TextAreaStyled
           placeholder="추가적인 반려사유가 있다면 작성해주세요."
-          onChange={e => setReasonText(e.target.value)}
+          value={reasonText}
+          onChange={e => {
+            setReasonText(e.target.value);
+            limitText(e.target.value);
+          }}
         />
+        <h3>&#40;{reasonText.length}/500&#41;</h3>
       </DetailDeniendReasonWrapper>
 
       <BtnAreaStyled>

--- a/src/components/molecules/Modal.tsx
+++ b/src/components/molecules/Modal.tsx
@@ -19,6 +19,7 @@ export interface ModalTitleProps extends ModalProps {
     | 'SubmitDeniedReason'
     | 'CancelDeniedReason'
     | 'Approving'
+    | 'LimitText'
     | null;
 }
 const selectModalTheme = (modalTitle: ModalTitleProps['modalTitle']) => {
@@ -77,6 +78,13 @@ const selectModalTheme = (modalTitle: ModalTitleProps['modalTitle']) => {
       revColorTheme = 'pink';
       btnText1 = '아니오';
       btnText2 = '네';
+      break;
+    case 'LimitText':
+      title = <p>반려 사유는 500자를 초과할 수 없습니다.</p>;
+      colorTheme = 'purple';
+      revColorTheme = 'violet';
+      btnText1 = '';
+      btnText2 = '확인';
       break;
     case null:
       title = <p />;

--- a/src/components/molecules/Modal.tsx
+++ b/src/components/molecules/Modal.tsx
@@ -80,7 +80,11 @@ const selectModalTheme = (modalTitle: ModalTitleProps['modalTitle']) => {
       btnText2 = '네';
       break;
     case 'LimitText':
-      title = <p>반려 사유는 500자를 초과할 수 없습니다.</p>;
+      title = (
+        <p>
+          반려 사유는 500자를 <br /> 초과할 수 없습니다.
+        </p>
+      );
       colorTheme = 'purple';
       revColorTheme = 'violet';
       btnText1 = '';


### PR DESCRIPTION
## 개요
반려사유 작성시 기타 인풋에 많은 내용을 넣을 경우 반려기록이 남지 않음

## 작업사항

 - 반려사유 textarea 우측 하단에 " 현재글자수/500 " 표현
 - 500자 넘을 시, "반려 사유는 500자를 초과할 수 없습니다."라는 모달창과 함께 500자 이상 작성할 수 없는 기능 구현.
 - modal 컴포넌츠에 LimitText라는 새로운 모달 케이스 추가

## 사용방법

## 기타